### PR TITLE
Support render prop in RNPublisherBanner

### DIFF
--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -55,9 +55,11 @@ class PublisherBanner extends Component {
   }
 
   render() {
-    return (
+    const { render, ...props } = this.props
+
+    const el = (
       <RNDFPBannerView
-        {...this.props}
+        {...props}
         style={[this.props.style, this.state.style]}
         onSizeChange={this.handleSizeChange}
         onAdFailedToLoad={this.handleAdFailedToLoad}
@@ -65,6 +67,10 @@ class PublisherBanner extends Component {
         ref={el => (this._bannerView = el)}
       />
     );
+
+    return render
+      ? render(el)
+      : el;
   }
 }
 
@@ -114,6 +120,8 @@ PublisherBanner.propTypes = {
   onAdClosed: func,
   onAdLeftApplication: func,
   onAppEvent: func,
+
+  render: func,
 
   targeting: shape({
     /**


### PR DESCRIPTION
Since RNPublisherBanner makes an ad request on mount, we need to be careful about where it is placed in the tree to prevent unintentional unmounts causing us to make ad requests more often than we should.

This means we need the flexibility of decoupling where in the component tree this component is mounted from where in the tree the banner itself is rendered. A render prop lets us do this.