### PR TITLE
fix loadBanner to work correctly with render prop

### DIFF
--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -19,15 +19,21 @@ class PublisherBanner extends Component {
     this.state = {
       style: {},
     };
+    this._bannerViewPromise = new Promise(resolve => this._onBannerViewRef = resolve);
+    this.loadBanner = this.loadBanner.bind(this);
   }
 
   componentDidMount() {
-    this.loadBanner();
+    if (!this.props.render) {
+        this.loadBanner();
+    }
   }
 
-  loadBanner() {
+  async loadBanner() {
+    const bannerView = await this._bannerViewPromise;
+
     UIManager.dispatchViewManagerCommand(
-      findNodeHandle(this._bannerView),
+      findNodeHandle(bannerView),
       UIManager.RNDFPBannerView.Commands.loadBanner,
       null,
     );
@@ -64,12 +70,12 @@ class PublisherBanner extends Component {
         onSizeChange={this.handleSizeChange}
         onAdFailedToLoad={this.handleAdFailedToLoad}
         onAppEvent={this.handleAppEvent}
-        ref={el => (this._bannerView = el)}
+        ref={this._onBannerViewRef}
       />
     );
 
     return render
-      ? render(el)
+      ? render(el, this.loadBanner)
       : el;
   }
 }


### PR DESCRIPTION
With the addition of the render prop, it became possible for loadBanner() to be called before we have a ref to banner view. With this fix, if the loadBanner() is called before ref is set, we wait for ref to be set before using it.

This commit also changes RNPublisherBanner to only call loadBanner() on mount if render prop isn't provided. If render is provided, the parent component which provided `render` prop will be passed `loadBanner` as argument, and it is its responsiblity to call it at the appropriate time.